### PR TITLE
Accept multiple locales/jurisdictions

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,12 @@ var Liberty = require('liberty'),
   _ = require('lodash');
 
 module.exports = function(jurisdiction) {
+  var jurisdictions;
+  if (arguments.length === 1 && _.isArray(arguments[0])) {
+    jurisdictions = _.toArray(arguments[0]);
+  } else {
+    jurisdictions = _.toArray(arguments);
+  }
   return {
     between: function(from, to, options) {
       var holidays,
@@ -26,7 +32,7 @@ module.exports = function(jurisdiction) {
       }).all();
 
       // use Liberty in the jurisdiction to get an array of holidays as millisecond since epoch
-      holidays = _.map(new Liberty(jurisdiction).between(from, to), function(day) {
+      holidays = _.map(new Liberty(jurisdictions).between(from, to), function(day) {
         return day.date.valueOf();
       });
 

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,6 @@ exports['returns Wed, excluding Queens Birthday and the exclusion'] = function(t
 exports['get holidays for two regions (varargs)'] = function(test) {
   // checks that public holidays for nz as well as nz_we are taken into account
   var days = workwork('nz', 'nz_we').between('2014-01-01', '2014-01-20');
-  console.log(days);
   test.equals(days.length, 11);
   test.done();
 };
@@ -29,7 +28,6 @@ exports['get holidays for two regions (varargs)'] = function(test) {
 exports['get holidays for two regions (array)'] = function(test) {
   // checks that public holidays for nz as well as nz_we are taken into account
   var days = workwork(['nz', 'nz_we']).between('2014-01-01', '2014-01-20');
-  console.log(days);
   test.equals(days.length, 11);
   test.done();
 };

--- a/test/index.js
+++ b/test/index.js
@@ -17,3 +17,19 @@ exports['returns Wed, excluding Queens Birthday and the exclusion'] = function(t
   test.equals(days[0].valueOf(), moment('2014-06-04').valueOf());
   test.done();
 };
+
+exports['get holidays for two regions (varargs)'] = function(test) {
+  // checks that public holidays for nz as well as nz_we are taken into account
+  var days = workwork('nz', 'nz_we').between('2014-01-01', '2014-01-20');
+  console.log(days);
+  test.equals(days.length, 11);
+  test.done();
+};
+
+exports['get holidays for two regions (array)'] = function(test) {
+  // checks that public holidays for nz as well as nz_we are taken into account
+  var days = workwork(['nz', 'nz_we']).between('2014-01-01', '2014-01-20');
+  console.log(days);
+  test.equals(days.length, 11);
+  test.done();
+};


### PR DESCRIPTION
As far as I can tell, it is currently not possible to pass multiple locales to workwork. Also, if I am not mistaken about the inner workings of the `liberty` package used by workwork, this makes it impossible to get a correct calculation of working days for a region, like, say `nz_we`. You can either pass `nz_we` to workwork but then national holidays for `nz` are not taken into account, or you pass in `nz` and then holidays for `nz_we` are not taken into account. 

To get a correct calculation for a time span that potentially includes public holidays for `nz` as well as `nz_we`, you need to be able to pass in both locales so that both locales are passed on to liberty.

See the tests in the second commit for examples  that will not work without this change.

This PR needs [liberty/#3](https://github.com/wombleton/liberty/pull/3) to be merged first to work.
